### PR TITLE
Abhi

### DIFF
--- a/projects2020/group03/.gitignore
+++ b/projects2020/group03/.gitignore
@@ -49,7 +49,10 @@ _deps
 *.exe
 *.out
 *.app
+*.x
 
+#results
+*.dat
 
 ### https://raw.github.com/github/gitignore/18aa6d83774d514da479d73a4beb864cd4220231/Fortran.gitignore
 

--- a/projects2020/group03/CMakeLists.txt
+++ b/projects2020/group03/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required (VERSION 3.10)
 project(stencil2d LANGUAGES Fortran CXX)
 
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})

--- a/projects2020/group03/CMakeLists.txt
+++ b/projects2020/group03/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project(stencil2d LANGUAGES Fortran CXX)
+cmake_minimum_required (VERSION 3.12)
+project(stencil2d LANGUAGES Fortran CXX C)
 
 if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	message (FATAL_ERROR "In-source builds not allowed. Please make a new directory (called a build directory) and run CMake from there. You may need to remove CMakeCache.txt. ")

--- a/projects2020/group03/src/openacc/stencil2d-base-array-acc.cpp
+++ b/projects2020/group03/src/openacc/stencil2d-base-array-acc.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <chrono>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <omp.h>
@@ -11,9 +12,91 @@
 
 namespace {
 
+// base versions for verification //
+
+void updateHalo(Storage3D<double> &inField) {
+  const int xInterior = inField.xMax() - inField.xMin();
+  const int yInterior = inField.yMax() - inField.yMin();
+
+  // bottom edge (without corners)
+  for (std::size_t k = 0; k < inField.zMax(); ++k) {
+    for (std::size_t j = 0; j < inField.yMin(); ++j) {
+      for (std::size_t i = inField.xMin(); i < inField.xMax(); ++i) {
+        inField(i, j, k) = inField(i, j + yInterior, k);
+      }
+    }
+  }
+
+  // top edge (without corners)
+  for (std::size_t k = 0; k < inField.zMax(); ++k) {
+    for (std::size_t j = inField.yMax(); j < inField.ySize(); ++j) {
+      for (std::size_t i = inField.xMin(); i < inField.xMax(); ++i) {
+        inField(i, j, k) = inField(i, j - yInterior, k);
+      }
+    }
+  }
+
+  // left edge (including corners)
+  for (std::size_t k = 0; k < inField.zMax(); ++k) {
+    for (std::size_t j = inField.yMin(); j < inField.yMax(); ++j) {
+      for (std::size_t i = 0; i < inField.xMin(); ++i) {
+        inField(i, j, k) = inField(i + xInterior, j, k);
+      }
+    }
+  }
+
+  // right edge (including corners)
+  for (std::size_t k = 0; k < inField.zMax(); ++k) {
+    for (std::size_t j = inField.yMin(); j < inField.yMax(); ++j) {
+      for (std::size_t i = inField.xMax(); i < inField.xSize(); ++i) {
+        inField(i, j, k) = inField(i - xInterior, j, k);
+      }
+    }
+  }
+}
+void apply_diffusion(Storage3D<double> &inField, Storage3D<double> &outField,
+                     double alpha, unsigned numIter, int x, int y, int z,
+                     int halo) {
+
+  Storage3D<double> tmp1Field(x, y, z, halo);
+
+  for (std::size_t iter = 0; iter < numIter; ++iter) {
+
+    updateHalo(inField);
+
+    for (std::size_t k = 0; k < inField.zMax(); ++k) {
+
+      // apply the initial laplacian
+      for (std::size_t j = inField.yMin() - 1; j < inField.yMax() + 1; ++j) {
+        for (std::size_t i = inField.xMin() - 1; i < inField.xMax() + 1; ++i) {
+          tmp1Field(i, j, 0) = -4.0 * inField(i, j, k) + inField(i - 1, j, k) +
+                               inField(i + 1, j, k) + inField(i, j - 1, k) +
+                               inField(i, j + 1, k);
+        }
+      }
+
+      // apply the second laplacian
+      for (std::size_t j = inField.yMin(); j < inField.yMax(); ++j) {
+        for (std::size_t i = inField.xMin(); i < inField.xMax(); ++i) {
+          double laplap = -4.0 * tmp1Field(i, j, 0) + tmp1Field(i - 1, j, 0) +
+                          tmp1Field(i + 1, j, 0) + tmp1Field(i, j - 1, 0) +
+                          tmp1Field(i, j + 1, 0);
+
+          // and update the field
+          if (iter == numIter - 1) {
+            outField(i, j, k) = inField(i, j, k) - alpha * laplap;
+          } else {
+            inField(i, j, k) = inField(i, j, k) - alpha * laplap;
+          }
+        }
+      }
+    }
+  }
+}
+
 // todo : add open acc calls here, straightforward
-void updateHalo(double *inField, int32_t xsize, int32_t ysize, int32_t zsize,
-                int32_t halosize) {
+void inline updateHalo(double *input, int32_t xsize, int32_t ysize,
+                       int32_t zsize, int32_t halosize) {
 
   std::size_t xMin = halosize;
   std::size_t xMax = xsize - halosize;
@@ -25,60 +108,162 @@ void updateHalo(double *inField, int32_t xsize, int32_t ysize, int32_t zsize,
   const int xInterior = xMax - xMin;
   const int yInterior = yMax - yMin;
 
-  // bottom edge (without corners)
-  for (std::size_t k = 0; k < zMin; ++k) {
-    for (std::size_t j = 0; j < yMin; ++j) {
-      for (std::size_t i = xMin; i < xMax; ++i) {
-        std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
-        std::size_t ijp1k = i + ((j + yInterior) * xsize) + (k * xsize * ysize);
+#pragma acc data present(input)
+  {
+#pragma acc parallel
+    {
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < zMax; ++k) {
+        for (std::size_t j = 0; j < yMin; ++j) {
+          for (std::size_t i = xMin; i < xMax; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ijp1k =
+                i + ((j + yInterior) * xsize) + (k * xsize * ysize);
 
-        inField[ijk] = inField[ijp1k];
-        // inField[k][j][i] = inField[k][j + yInterior][i];
+            input[ijk] = input[ijp1k];
+            // input[k][j][i] = input[k][j + yInterior][i];
+          }
+        }
       }
-    }
-  }
 
-  // top edge (without corners)
-  for (std::size_t k = 0; k < zMin; ++k) {
-    for (std::size_t j = yMax; j < ysize; ++j) {
-      for (std::size_t i = xMin; i < xMax; ++i) {
-        std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
-        std::size_t ijm1k = i + ((j - yInterior) * xsize) + (k * xsize * ysize);
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < zMax; ++k) {
+        for (std::size_t j = yMax; j < ysize; ++j) {
+          for (std::size_t i = xMin; i < xMax; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ijm1k =
+                i + ((j - yInterior) * xsize) + (k * xsize * ysize);
 
-        inField[ijk] = inField[ijm1k];
-        // inField[k][j][i] = inField[k][j - yInterior][i];
+            input[ijk] = input[ijm1k];
+            // input[k][j][i] = input[k][j - yInterior][i];
+          }
+        }
       }
-    }
-  }
 
-  // left edge (including corners)
-  for (std::size_t k = 0; k < zMin; ++k) {
-    for (std::size_t j = yMin; j < yMax; ++j) {
-      for (std::size_t i = 0; i < xMin; ++i) {
-        std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
-        std::size_t ip1jk = i + xInterior + (j * xsize) + (k * xsize * ysize);
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < zMax; ++k) {
+        for (std::size_t j = yMin; j < yMax; ++j) {
+          for (std::size_t i = 0; i < xMin; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ip1jk =
+                i + xInterior + (j * xsize) + (k * xsize * ysize);
 
-        inField[ijk] = inField[ip1jk];
-        // inField[k][j][i] = inField(i + xInterior, j, k);
+            input[ijk] = input[ip1jk];
+            // input[k][j][i] = input(i + xInterior, j, k);
+          }
+        }
       }
-    }
-  }
 
-  // right edge (including corners)
-  for (std::size_t k = 0; k < zMin; ++k) {
-    for (std::size_t j = yMin; j < yMax; ++j) {
-      for (std::size_t i = xMax; i < xsize; ++i) {
-        std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
-        std::size_t im1jk = i - xInterior + (j * xsize) + (k * xsize * ysize);
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < zMax; ++k) {
+        for (std::size_t j = yMin; j < yMax; ++j) {
+          for (std::size_t i = xMax; i < xsize; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t im1jk =
+                i - xInterior + (j * xsize) + (k * xsize * ysize);
 
-        inField[ijk] = inField[im1jk];
-        // inField[k][j][i] = inField[i - xInterior][j][k];
+            input[ijk] = input[im1jk];
+            // input[k][j][i] = input[i - xInterior][j][k];
+          }
+        }
       }
     }
   }
 }
 
-void apply_diffusion(double *inField, double *outField, double alpha,
+void inline updateHalo_output(double *output, int32_t xsize, int32_t ysize,
+                              int32_t zsize, int32_t halosize) {
+  std::size_t xMin = halosize;
+  std::size_t xMax = xsize - halosize;
+  std::size_t yMin = halosize;
+  std::size_t yMax = ysize - halosize;
+  std::size_t zMin = 0;
+  std::size_t zMax = zsize;
+
+  const int xInterior = xMax - xMin;
+  const int yInterior = yMax - yMin;
+
+  const std::size_t sizeOf3DField = (xsize) * (ysize) * (zsize);
+
+  // todo : do you need the copy in?
+  // #pragma acc data copyin(output [0:sizeOf3DField])
+  {
+// #pragma acc enter data
+// copyin(output [0:sizeOf3DField])
+// bottom edge (without corners)
+#pragma acc data present(output)
+    {
+#pragma acc parallel
+      {
+#pragma acc loop independent gang worker vector collapse(3)
+        for (std::size_t k = 0; k < zMax; ++k) {
+          for (std::size_t j = 0; j < yMin; ++j) {
+            for (std::size_t i = xMin; i < xMax; ++i) {
+              std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+              std::size_t ijp1k =
+                  i + ((j + yInterior) * xsize) + (k * xsize * ysize);
+
+              output[ijk] = output[ijp1k];
+              // output[k][j][i] = output[k][j + yInterior][i];
+            }
+          }
+        }
+
+        // top edge (without corners)
+// #pragma acc parallel present(output) async(2)
+#pragma acc loop independent gang worker vector collapse(3)
+        for (std::size_t k = 0; k < zMax; ++k) {
+          for (std::size_t j = yMax; j < ysize; ++j) {
+            for (std::size_t i = xMin; i < xMax; ++i) {
+              std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+              std::size_t ijm1k =
+                  i + ((j - yInterior) * xsize) + (k * xsize * ysize);
+
+              output[ijk] = output[ijm1k];
+              // output[k][j][i] = output[k][j - yInterior][i];
+            }
+          }
+        }
+
+        // left edge (including corners)
+// #pragma acc parallel present(output) async(3)
+#pragma acc loop independent gang worker vector collapse(3)
+        for (std::size_t k = 0; k < zMax; ++k) {
+          for (std::size_t j = yMin; j < yMax; ++j) {
+            for (std::size_t i = 0; i < xMin; ++i) {
+              std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+              std::size_t ip1jk =
+                  i + xInterior + (j * xsize) + (k * xsize * ysize);
+
+              output[ijk] = output[ip1jk];
+              // output[k][j][i] = output(i + xInterior, j, k);
+            }
+          }
+        }
+
+        // right edge (including corners)
+// #pragma acc parallel present(output) async(4)
+#pragma acc loop independent gang worker vector collapse(3)
+        for (std::size_t k = 0; k < zMax; ++k) {
+          for (std::size_t j = yMin; j < yMax; ++j) {
+            for (std::size_t i = xMax; i < xsize; ++i) {
+              std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+              std::size_t im1jk =
+                  i - xInterior + (j * xsize) + (k * xsize * ysize);
+
+              output[ijk] = output[im1jk];
+              // output[k][j][i] = output[i - xInterior][j][k];
+            }
+          }
+        }
+      }
+    }
+  }
+  // #pragma acc exit data
+  // copyout(output [0:sizeOf3DField])
+}
+
+void apply_diffusion(double *input, double *output, double alpha,
                      unsigned numIter, int x, int y, int z, int halo) {
   std::size_t xsize = x;
   std::size_t xMin = halo;
@@ -97,21 +282,19 @@ void apply_diffusion(double *inField, double *outField, double alpha,
 
   double *tmp1Field = new double[sizeOf2DField];
 
-#pragma acc data \
-	copyin(inField [0:sizeOf3DField]) \
-	copy(outField [0:sizeOf3DField]) \
-	create(tmp1Field[0:sizeOf2DField])
+#pragma acc enter data create(tmp1Field [0:sizeOf2DField])
   {
     for (std::size_t iter = 0; iter < numIter; ++iter) {
 
       // TODO : make this an acc routine
       // todo : turn this into a cuda kernel and call from acc???
-      updateHalo(inField, xsize, ysize, z, halo);
+      updateHalo(input, xsize, ysize, z, halo);
+      // #pragma acc update device(input[:sizeOf3DField])
       // todo : if this is not on the gpu, the gpu copy needs to be updated?
-      // # pragma acc update device(inField[0:n])
+      // # pragma acc update device(input[0:n])
 
       for (std::size_t k = 0; k < zMax; ++k) {
-#pragma acc parallel present(inField, tmp1Field)
+#pragma acc parallel present(input, tmp1Field)
 #pragma acc loop gang vector collapse(2)
         for (std::size_t j = yMin - 1; j < yMax + 1; ++j) {
           for (std::size_t i = xMin - 1; i < xMax + 1; ++i) {
@@ -122,12 +305,12 @@ void apply_diffusion(double *inField, double *outField, double alpha,
             std::size_t ijp1k = i + ((j + 1) * xsize) + (k * xsize * ysize);
             std::size_t ijm1k = i + ((j - 1) * xsize) + (k * xsize * ysize);
 
-            tmp1Field[j * xsize + i] = -4.0 * inField[ijk] + inField[im1jk] +
-                                       inField[ip1jk] + inField[ijm1k] +
-                                       inField[ijp1k];
+            tmp1Field[j * xsize + i] = -4.0 * input[ijk] + input[im1jk] +
+                                       input[ip1jk] + input[ijm1k] +
+                                       input[ijp1k];
           }
         }
-#pragma acc parallel present(inField, tmp1Field)
+#pragma acc parallel present(input, tmp1Field)
 #pragma acc loop gang vector collapse(2)
         for (std::size_t j = yMin; j < yMax; ++j) {
           for (std::size_t i = xMin; i < xMax; ++i) {
@@ -143,24 +326,26 @@ void apply_diffusion(double *inField, double *outField, double alpha,
 
             // and update the field
             std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
-            inField[ijk] = inField[ijk] - alpha * laplap;
+            input[ijk] = input[ijk] - alpha * laplap;
           }
         }
       }
       if (iter == numIter - 1) {
-#pragma acc parallel present(inField, outField)
+#pragma acc parallel present(input, output)
 #pragma acc loop independent gang worker vector collapse(3)
         for (std::size_t k = 0; k < zMax; ++k) {
           for (std::size_t j = yMin; j < yMax; ++j) {
             for (std::size_t i = xMin; i < xMax; ++i) {
               std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
-              outField[ijk] = inField[ijk];
+              output[ijk] = input[ijk];
             }
           }
         }
       }
     }
   }
+#pragma acc exit data delete (tmp1Field [0:sizeOf2DField])
+
   delete[] tmp1Field;
 }
 
@@ -186,7 +371,7 @@ int main(int argc, char const *argv[]) {
   int x = atoi(argv[2]);
   int y = atoi(argv[4]);
   int z = atoi(argv[6]);
-  int iter = atoi(argv[8]);
+  unsigned int iter = atoi(argv[8]);
   int nHalo = 3;
   assert(x > 0 && y > 0 && z > 0 && iter > 0);
 
@@ -235,6 +420,9 @@ int main(int argc, char const *argv[]) {
   input_3D.writeFile(fout);
   fout.close();
 
+#pragma acc enter data copyin(input [0:sizeOf3DField])                         \
+    copyin(output [0:sizeOf3DField])
+
 #ifdef CRAYPAT
   PAT_record(PAT_STATE_ON);
 #endif
@@ -249,7 +437,9 @@ int main(int argc, char const *argv[]) {
 #endif
 
   // updateHalo(output_3D);
-  updateHalo(output, xsize, ysize, zsize, nHalo);
+  updateHalo_output(output, xsize, ysize, zsize, nHalo);
+#pragma acc exit data copyout(output [0:sizeOf3DField]) delete (               \
+    input [0:sizeOf3DField])
 
   // copy output array to output_3D for writing to file
   for (std::size_t k = 0; k < zsize; ++k) {
@@ -261,6 +451,31 @@ int main(int argc, char const *argv[]) {
     }
   }
 
+#ifdef VALIDATE
+  //--------------------------//
+  // run base and verification //
+  //--------------------------//
+  Storage3D<double> input_V(x, y, z, nHalo);
+  input_V.initialize();
+  Storage3D<double> output_V(x, y, z, nHalo);
+  output_V.initialize();
+  apply_diffusion(input_V, output_V, alpha, iter, x, y, z, nHalo);
+  updateHalo(output_V);
+  double L2_error = 0;
+  for (std::size_t k = 0; k < zsize; ++k) {
+    for (std::size_t j = 0; j < ysize; ++j) {
+      for (std::size_t i = 0; i < xsize; ++i) {
+        L2_error += std::pow((output_3D(i, j, k) - output_V(i, j, k)), 2);
+      }
+    }
+  }
+  L2_error = sqrt(L2_error);
+  std::cout << " L2 Error = " << L2_error << std::endl;
+  //--------------------------//
+  // run base and verification //
+  //--------------------------//
+#endif
+
   fout.open("out_field.dat", std::ios::binary | std::ofstream::trunc);
   output_3D.writeFile(fout);
   fout.close();
@@ -270,6 +485,10 @@ int main(int argc, char const *argv[]) {
       std::chrono::duration<double, std::milli>(diff).count() / 1000.;
   reportTime(output_3D, iter, timeDiff);
 
+  std::ofstream os;
+  os.open("time_1.dat", std::ofstream::app);
+  os << timeDiff << std::endl;
+  os.close();
   delete[] input;
   delete[] output;
 

--- a/projects2020/group03/src/openacc_split/CMakeLists.txt
+++ b/projects2020/group03/src/openacc_split/CMakeLists.txt
@@ -1,20 +1,5 @@
-add_executable (
-	stencil2d_openacc_split
-		stencil2d.f
-		diffusion_openacc_split.f
-)
-target_compile_definitions (
-	stencil2d_openacc_split PRIVATE
-		-D m_diffusion=m_diffusion_openacc_split
-)
-target_link_libraries (
-	stencil2d_openacc_split
-		utils
-		partitioner
-		halo_mpi
-		OpenACC::Fortran
-		OpenMP::OpenMP_Fortran
-		MPI::MPI_Fortran
-)
+include (stencil2d-arrayFusion-acc.cmake)
+include (stencil2d_openacc_split.cmake)
+
 
 # vim : filetype=cmake noexpandtab tabstop=2 softtabs=2 shiftwidth=2 :

--- a/projects2020/group03/src/openacc_split/stencil2d-arrayFusion-accsplit.cmake
+++ b/projects2020/group03/src/openacc_split/stencil2d-arrayFusion-accsplit.cmake
@@ -1,0 +1,12 @@
+add_executable (
+	stencil2d-arrayFusion-accsplit
+	stencil2d-arrayFusion-accsplit.cpp
+)
+
+target_link_libraries (
+	stencil2d-arrayFusion-acc-split
+		OpenACC::CXX
+		OpenMP::CXX
+)
+
+# vim : filetype=cmake noexpandtab tabstop=2 softtabs=2 shiftwidth=2 :

--- a/projects2020/group03/src/openacc_split/stencil2d-arrayFusion-accsplit.cpp
+++ b/projects2020/group03/src/openacc_split/stencil2d-arrayFusion-accsplit.cpp
@@ -1,0 +1,752 @@
+#include <omp.h>
+
+#include <cassert>
+#include <chrono>
+#include <cmath>
+
+#include <fstream>
+#include <iostream>
+
+#ifdef CRAYPAT
+#include "pat_api.h"
+#endif
+#include "../utils.h"
+
+#define split_factor 1
+
+typedef double float_type;
+// typedef float float_type;
+
+namespace {
+
+// base versions for verification //
+
+void updateHalo(Storage3D<float_type> &inField) {
+  const int xInterior = inField.xMax() - inField.xMin();
+  const int yInterior = inField.yMax() - inField.yMin();
+
+  // bottom edge (without corners)
+  for (std::size_t k = 0; k < inField.zMax(); ++k) {
+    for (std::size_t j = 0; j < inField.yMin(); ++j) {
+      for (std::size_t i = inField.xMin(); i < inField.xMax(); ++i) {
+        inField(i, j, k) = inField(i, j + yInterior, k);
+      }
+    }
+  }
+
+  // top edge (without corners)
+  for (std::size_t k = 0; k < inField.zMax(); ++k) {
+    for (std::size_t j = inField.yMax(); j < inField.ySize(); ++j) {
+      for (std::size_t i = inField.xMin(); i < inField.xMax(); ++i) {
+        inField(i, j, k) = inField(i, j - yInterior, k);
+      }
+    }
+  }
+
+  // left edge (including corners)
+  for (std::size_t k = 0; k < inField.zMax(); ++k) {
+    for (std::size_t j = inField.yMin(); j < inField.yMax(); ++j) {
+      for (std::size_t i = 0; i < inField.xMin(); ++i) {
+        inField(i, j, k) = inField(i + xInterior, j, k);
+      }
+    }
+  }
+
+  // right edge (including corners)
+  for (std::size_t k = 0; k < inField.zMax(); ++k) {
+    for (std::size_t j = inField.yMin(); j < inField.yMax(); ++j) {
+      for (std::size_t i = inField.xMax(); i < inField.xSize(); ++i) {
+        inField(i, j, k) = inField(i - xInterior, j, k);
+      }
+    }
+  }
+}
+
+void apply_diffusion(Storage3D<float_type> &inField,
+                     Storage3D<float_type> &outField, float_type alpha,
+                     unsigned numIter, int x, int y, int z, int halo) {
+
+  Storage3D<float_type> tmp1Field(x, y, z, halo);
+
+  for (std::size_t iter = 0; iter < numIter; ++iter) {
+
+    updateHalo(inField);
+
+    for (std::size_t k = 0; k < inField.zMax(); ++k) {
+
+      // apply the initial laplacian
+      for (std::size_t j = inField.yMin() - 1; j < inField.yMax() + 1; ++j) {
+        for (std::size_t i = inField.xMin() - 1; i < inField.xMax() + 1; ++i) {
+          tmp1Field(i, j, 0) = -4.0 * inField(i, j, k) + inField(i - 1, j, k) +
+                               inField(i + 1, j, k) + inField(i, j - 1, k) +
+                               inField(i, j + 1, k);
+        }
+      }
+
+      // apply the second laplacian
+      for (std::size_t j = inField.yMin(); j < inField.yMax(); ++j) {
+        for (std::size_t i = inField.xMin(); i < inField.xMax(); ++i) {
+          float_type laplap = -4.0 * tmp1Field(i, j, 0) +
+                              tmp1Field(i - 1, j, 0) + tmp1Field(i + 1, j, 0) +
+                              tmp1Field(i, j - 1, 0) + tmp1Field(i, j + 1, 0);
+
+          // and update the field
+          if (iter == numIter - 1) {
+            outField(i, j, k) = inField(i, j, k) - alpha * laplap;
+          } else {
+            inField(i, j, k) = inField(i, j, k) - alpha * laplap;
+          }
+        }
+      }
+    }
+  }
+}
+
+// base version for verification //
+
+// overloaded function with cstd arrays
+// #pragma acc routine seq
+void inline updateHalo_gpu(float_type *input, int32_t xsize, int32_t ysize,
+                           int32_t zsize, int32_t halosize, int32_t z_split) {
+  std::size_t xMin = halosize;
+  std::size_t xMax = xsize - halosize;
+  std::size_t yMin = halosize;
+  std::size_t yMax = ysize - halosize;
+  std::size_t zMin = 0;
+  std::size_t zMax = zsize;
+
+  const int xInterior = xMax - xMin;
+  const int yInterior = yMax - yMin;
+
+  const std::size_t sizeOf3DField = (xsize) * (ysize) * (zsize);
+
+// bottom edge (without corners)
+#pragma acc data present(input)
+  {
+#pragma acc parallel
+    {
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < z_split; ++k) {
+        for (std::size_t j = 0; j < yMin; ++j) {
+          for (std::size_t i = xMin; i < xMax; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ijp1k =
+                i + ((j + yInterior) * xsize) + (k * xsize * ysize);
+
+            input[ijk] = input[ijp1k];
+            // input[k][j][i] = input[k][j + yInterior][i];
+          }
+        }
+      }
+
+      // top edge (without corners)
+// #pragma acc parallel present(input) async(2)
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < z_split; ++k) {
+        for (std::size_t j = yMax; j < ysize; ++j) {
+          for (std::size_t i = xMin; i < xMax; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ijm1k =
+                i + ((j - yInterior) * xsize) + (k * xsize * ysize);
+
+            input[ijk] = input[ijm1k];
+            // input[k][j][i] = input[k][j - yInterior][i];
+          }
+        }
+      }
+
+      // left edge (including corners)
+// #pragma acc parallel present(input) async(3)
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < z_split; ++k) {
+        for (std::size_t j = yMin; j < yMax; ++j) {
+          for (std::size_t i = 0; i < xMin; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ip1jk =
+                i + xInterior + (j * xsize) + (k * xsize * ysize);
+
+            input[ijk] = input[ip1jk];
+            // input[k][j][i] = input(i + xInterior, j, k);
+          }
+        }
+      }
+
+      // right edge (including corners)
+// #pragma acc parallel present(input) async(4)
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < z_split; ++k) {
+        for (std::size_t j = yMin; j < yMax; ++j) {
+          for (std::size_t i = xMax; i < xsize; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t im1jk =
+                i - xInterior + (j * xsize) + (k * xsize * ysize);
+
+            input[ijk] = input[im1jk];
+            // input[k][j][i] = input[i - xInterior][j][k];
+          }
+        }
+      }
+    }
+  }
+}
+// #pragma acc exit data
+// copyout(input [0:sizeOf3DField])
+
+void inline updateHalo_cpu(float_type *input, int32_t xsize, int32_t ysize,
+                           int32_t zsize, int32_t halosize, int32_t z_split) {
+  std::size_t xMin = halosize;
+  std::size_t xMax = xsize - halosize;
+  std::size_t yMin = halosize;
+  std::size_t yMax = ysize - halosize;
+  std::size_t zMin = 0;
+  std::size_t zMax = zsize;
+
+  const int xInterior = xMax - xMin;
+  const int yInterior = yMax - yMin;
+
+  const std::size_t sizeOf3DField = (xsize) * (ysize) * (zsize);
+
+  // todo : do you need the copy in?
+  // #pragma acc data copyin(input [0:sizeOf3DField])
+  {
+// #pragma acc enter data
+// copyin(input [0:sizeOf3DField])
+// bottom edge (without corners)
+// #pragma acc data present(input)
+// {
+#pragma omp parallel
+    {
+#pragma omp for nowait
+      for (std::size_t k = z_split; k < zMax; ++k) {
+        for (std::size_t j = 0; j < yMin; ++j) {
+          for (std::size_t i = xMin; i < xMax; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ijp1k =
+                i + ((j + yInterior) * xsize) + (k * xsize * ysize);
+
+            input[ijk] = input[ijp1k];
+            // input[k][j][i] = input[k][j + yInterior][i];
+          }
+        }
+      }
+
+      // top edge (without corners)
+#pragma omp for nowait
+      for (std::size_t k = z_split; k < zMax; ++k) {
+        for (std::size_t j = yMax; j < ysize; ++j) {
+          for (std::size_t i = xMin; i < xMax; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ijm1k =
+                i + ((j - yInterior) * xsize) + (k * xsize * ysize);
+
+            input[ijk] = input[ijm1k];
+            // input[k][j][i] = input[k][j - yInterior][i];
+          }
+        }
+      }
+
+      // left edge (including corners)
+#pragma omp for nowait
+      for (std::size_t k = z_split; k < zMax; ++k) {
+        for (std::size_t j = yMin; j < yMax; ++j) {
+          for (std::size_t i = 0; i < xMin; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ip1jk =
+                i + xInterior + (j * xsize) + (k * xsize * ysize);
+
+            input[ijk] = input[ip1jk];
+            // input[k][j][i] = input(i + xInterior, j, k);
+          }
+        }
+      }
+
+      // right edge (including corners)
+#pragma omp for nowait
+      for (std::size_t k = z_split; k < zMax; ++k) {
+        for (std::size_t j = yMin; j < yMax; ++j) {
+          for (std::size_t i = xMax; i < xsize; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t im1jk =
+                i - xInterior + (j * xsize) + (k * xsize * ysize);
+
+            input[ijk] = input[im1jk];
+            // input[k][j][i] = input[i - xInterior][j][k];
+          }
+        }
+      }
+    }
+    // }
+  }
+}
+
+//
+
+void inline updateHalo_gpu_out(float_type *output, int32_t xsize, int32_t ysize,
+                               int32_t zsize, int32_t halosize,
+                               int32_t z_split) {
+  std::size_t xMin = halosize;
+  std::size_t xMax = xsize - halosize;
+  std::size_t yMin = halosize;
+  std::size_t yMax = ysize - halosize;
+  std::size_t zMin = 0;
+  std::size_t zMax = zsize;
+
+  const int xInterior = xMax - xMin;
+  const int yInterior = yMax - yMin;
+
+  const std::size_t sizeOf3DField = (xsize) * (ysize) * (zsize);
+  std::size_t split_N =
+      (xMax - 1) + ((yMax - 1) * xsize) + ((z_split - 1) * xsize * ysize);
+
+#pragma acc data present(output [0:split_N])
+  {
+#pragma acc parallel
+    {
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < z_split; ++k) {
+        for (std::size_t j = 0; j < yMin; ++j) {
+          for (std::size_t i = xMin; i < xMax; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ijp1k =
+                i + ((j + yInterior) * xsize) + (k * xsize * ysize);
+
+            output[ijk] = output[ijp1k];
+            // output[k][j][i] = output[k][j + yInterior][i];
+          }
+        }
+      }
+
+      // top edge (without corners)
+// #pragma acc parallel present(output) async(2)
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < z_split; ++k) {
+        for (std::size_t j = yMax; j < ysize; ++j) {
+          for (std::size_t i = xMin; i < xMax; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ijm1k =
+                i + ((j - yInterior) * xsize) + (k * xsize * ysize);
+
+            output[ijk] = output[ijm1k];
+            // output[k][j][i] = output[k][j - yInterior][i];
+          }
+        }
+      }
+
+      // left edge (including corners)
+// #pragma acc parallel present(output) async(3)
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < z_split; ++k) {
+        for (std::size_t j = yMin; j < yMax; ++j) {
+          for (std::size_t i = 0; i < xMin; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ip1jk =
+                i + xInterior + (j * xsize) + (k * xsize * ysize);
+
+            output[ijk] = output[ip1jk];
+            // output[k][j][i] = output(i + xInterior, j, k);
+          }
+        }
+      }
+
+      // right edge (including corners)
+// #pragma acc parallel present(output) async(4)
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < z_split; ++k) {
+        for (std::size_t j = yMin; j < yMax; ++j) {
+          for (std::size_t i = xMax; i < xsize; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t im1jk =
+                i - xInterior + (j * xsize) + (k * xsize * ysize);
+
+            output[ijk] = output[im1jk];
+            // output[k][j][i] = output[i - xInterior][j][k];
+          }
+        }
+      }
+    }
+  }
+}
+// #pragma acc exit data
+// copyout(output [0:sizeOf3DField])
+// namespace
+
+//
+
+// overloaded function with cstd arrays
+void apply_diffusion(float_type *input, float_type *output, float_type alpha,
+                     unsigned int numIter, int x, int y, int z, int halo) {
+
+  // TODO : temp array or restrict input to avoid aliasing?
+  std::size_t xsize = x;
+  std::size_t xMin = halo;
+  std::size_t xMax = xsize - halo;
+
+  std::size_t ysize = y;
+  std::size_t yMin = halo;
+  std::size_t yMax = ysize - halo;
+
+  std::size_t zMin = 0;
+  std::size_t zMax = z;
+
+  // float split_factor = 1;
+  std::size_t z_split = floor(split_factor * zMax);
+  std::size_t split_N =
+      (xMax - 1) + ((yMax - 1) * xsize) + ((z_split - 1) * xsize * ysize);
+
+  std::size_t sizeOf3DField = (xsize) * (ysize)*z;
+
+  for (std::size_t iter = 0; iter < numIter; ++iter) {
+
+    // #pragma acc parallel present(input)
+    updateHalo_gpu(input, xsize, ysize, z, halo, z_split);
+    // std::cout << "this is gpu part " << std::endl;
+
+#pragma acc parallel present(input [0:split_N], output [0:split_N]) async
+    {
+#pragma acc loop independent gang worker vector collapse(3)
+      for (std::size_t k = 0; k < z_split; ++k) {
+        for (std::size_t j = yMin; j < yMax; ++j) {
+          for (std::size_t i = xMin; i < xMax; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ip1jk = (i + 1) + (j * xsize) + (k * xsize * ysize);
+            std::size_t im1jk = (i - 1) + (j * xsize) + (k * xsize * ysize);
+            std::size_t ijp1k = i + ((j + 1) * xsize) + (k * xsize * ysize);
+            std::size_t ijm1k = i + ((j - 1) * xsize) + (k * xsize * ysize);
+            std::size_t im1jm1k =
+                i - 1 + ((j - 1) * xsize) + k * (xsize * ysize);
+            std::size_t im1jp1k =
+                i - 1 + ((j + 1) * xsize) + k * (xsize * ysize);
+            std::size_t ip1jm1k =
+                i + 1 + ((j - 1) * xsize) + k * (xsize * ysize);
+            std::size_t ip1jp1k =
+                i + 1 + ((j + 1) * xsize) + k * (xsize * ysize);
+            std::size_t im2jk = (i - 2) + (j * xsize) + k * (xsize * ysize);
+            std::size_t ip2jk = (i + 2) + (j * xsize) + k * (xsize * ysize);
+            std::size_t ijm2k = i + ((j - 2) * xsize) + k * (xsize * ysize);
+            std::size_t ijp2k = i + ((j + 2) * xsize) + k * (xsize * ysize);
+
+            float_type partial_laplap =
+                // 20*input[ijk] -
+                -8 * (input[im1jk] + input[ip1jk] + input[ijm1k] +
+                      input[ijp1k]) +
+                2 * (input[im1jm1k] + input[ip1jm1k] + input[im1jp1k] +
+                     input[ip1jp1k]) +
+                1 * (input[im2jk] + input[ip2jk] + input[ijm2k] + input[ijp2k]);
+
+            // TODO : check if independent
+            output[ijk] =
+                (1 - 20 * alpha) * input[ijk] - alpha * partial_laplap;
+          }
+        }
+      }
+
+      if (iter != numIter - 1) {
+// num_gangs(2) num_workers(4)    vector_length(128)
+// #pragma acc parallel present(input, output)
+#pragma acc loop independent gang worker vector collapse(3)
+        for (std::size_t k = 0; k < z_split; ++k) {
+          for (std::size_t j = yMin; j < yMax; ++j) {
+            for (std::size_t i = xMin; i < xMax; ++i) {
+              std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+              // output[ijk] = input[ijk];
+              input[ijk] = output[ijk];
+            }
+          }
+        }
+      }
+    }
+
+    ///////////////////////cpu//////////////////////
+    updateHalo_cpu(input, xsize, ysize, z, halo, z_split);
+    // std::cout << "this is cpu part " << std::endl;
+
+#pragma omp parallel
+    {
+#pragma omp for
+      for (std::size_t k = z_split; k < zMax; ++k) {
+        for (std::size_t j = yMin; j < yMax; ++j) {
+          for (std::size_t i = xMin; i < xMax; ++i) {
+            std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+            std::size_t ip1jk = (i + 1) + (j * xsize) + (k * xsize * ysize);
+            std::size_t im1jk = (i - 1) + (j * xsize) + (k * xsize * ysize);
+            std::size_t ijp1k = i + ((j + 1) * xsize) + (k * xsize * ysize);
+            std::size_t ijm1k = i + ((j - 1) * xsize) + (k * xsize * ysize);
+            std::size_t im1jm1k =
+                i - 1 + ((j - 1) * xsize) + k * (xsize * ysize);
+            std::size_t im1jp1k =
+                i - 1 + ((j + 1) * xsize) + k * (xsize * ysize);
+            std::size_t ip1jm1k =
+                i + 1 + ((j - 1) * xsize) + k * (xsize * ysize);
+            std::size_t ip1jp1k =
+                i + 1 + ((j + 1) * xsize) + k * (xsize * ysize);
+            std::size_t im2jk = (i - 2) + (j * xsize) + k * (xsize * ysize);
+            std::size_t ip2jk = (i + 2) + (j * xsize) + k * (xsize * ysize);
+            std::size_t ijm2k = i + ((j - 2) * xsize) + k * (xsize * ysize);
+            std::size_t ijp2k = i + ((j + 2) * xsize) + k * (xsize * ysize);
+
+            float_type partial_laplap =
+                // 20*input[ijk] -
+                -8 * (input[im1jk] + input[ip1jk] + input[ijm1k] +
+                      input[ijp1k]) +
+                2 * (input[im1jm1k] + input[ip1jm1k] + input[im1jp1k] +
+                     input[ip1jp1k]) +
+                1 * (input[im2jk] + input[ip2jk] + input[ijm2k] + input[ijp2k]);
+
+            // TODO : check if independent
+            output[ijk] =
+                (1 - 20 * alpha) * input[ijk] - alpha * partial_laplap;
+          }
+        }
+      }
+
+      if (iter != numIter - 1) {
+// num_gangs(2) num_workers(4)    vector_length(128)
+// #pragma acc parallel present(input, output)
+#pragma omp for
+        for (std::size_t k = z_split; k < zMax; ++k) {
+          for (std::size_t j = yMin; j < yMax; ++j) {
+            for (std::size_t i = xMin; i < xMax; ++i) {
+              std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+              // output[ijk] = input[ijk];
+              input[ijk] = output[ijk];
+            }
+          }
+        }
+      }
+    }
+  }
+
+  //   for (std::size_t iter = 0; iter < numIter; ++iter) {
+  //
+  //     ///////////////////////cpu//////////////////////
+  //     updateHalo_cpu(input, xsize, ysize, z, halo, z_split);
+  //     // std::cout << "this is cpu part " << std::endl;
+  //
+  // #pragma omp parallel
+  //     {
+  // #pragma omp for
+  //       for (std::size_t k = z_split; k < zMax; ++k) {
+  //         for (std::size_t j = yMin; j < yMax; ++j) {
+  //           for (std::size_t i = xMin; i < xMax; ++i) {
+  //             std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+  //             std::size_t ip1jk = (i + 1) + (j * xsize) + (k * xsize *
+  //             ysize); std::size_t im1jk = (i - 1) + (j * xsize) + (k *
+  //             xsize
+  //             * ysize); std::size_t ijp1k = i + ((j + 1) * xsize) + (k *
+  //             xsize * ysize); std::size_t ijm1k = i + ((j - 1) * xsize) +
+  //             (k
+  //             * xsize * ysize); std::size_t im1jm1k =
+  //                 i - 1 + ((j - 1) * xsize) + k * (xsize * ysize);
+  //             std::size_t im1jp1k =
+  //                 i - 1 + ((j + 1) * xsize) + k * (xsize * ysize);
+  //             std::size_t ip1jm1k =
+  //                 i + 1 + ((j - 1) * xsize) + k * (xsize * ysize);
+  //             std::size_t ip1jp1k =
+  //                 i + 1 + ((j + 1) * xsize) + k * (xsize * ysize);
+  //             std::size_t im2jk = (i - 2) + (j * xsize) + k * (xsize *
+  //             ysize); std::size_t ip2jk = (i + 2) + (j * xsize) + k *
+  //             (xsize
+  //             * ysize); std::size_t ijm2k = i + ((j - 2) * xsize) + k *
+  //             (xsize * ysize); std::size_t ijp2k = i + ((j + 2) * xsize) +
+  //             k
+  //             * (xsize * ysize);
+  //
+  //             float_type partial_laplap =
+  //                 // 20*input[ijk] -
+  //                 -8 * (input[im1jk] + input[ip1jk] + input[ijm1k] +
+  //                       input[ijp1k]) +
+  //                 2 * (input[im1jm1k] + input[ip1jm1k] + input[im1jp1k] +
+  //                      input[ip1jp1k]) +
+  //                 1 * (input[im2jk] + input[ip2jk] + input[ijm2k] +
+  //                 input[ijp2k]);
+  //
+  //             // TODO : check if independent
+  //             output[ijk] =
+  //                 (1 - 20 * alpha) * input[ijk] - alpha * partial_laplap;
+  //           }
+  //         }
+  //       }
+  //
+  //       if (iter != numIter - 1) {
+  // // num_gangs(2) num_workers(4)    vector_length(128)
+  // // #pragma acc parallel present(input, output)
+  // #pragma omp for
+  //         for (std::size_t k = z_split; k < zMax; ++k) {
+  //           for (std::size_t j = yMin; j < yMax; ++j) {
+  //             for (std::size_t i = xMin; i < xMax; ++i) {
+  //               std::size_t ijk = i + (j * xsize) + (k * xsize * ysize);
+  //               // output[ijk] = input[ijk];
+  //               input[ijk] = output[ijk];
+  //             }
+  //           }
+  //         }
+  //       }
+  //     }
+  //   }
+  //////////////////////cpu/////////////////////////
+
+} // namespace
+
+void reportTime(const Storage3D<float_type> &storage, int nIter,
+                float_type diff) {
+  std::cout << "# ranks nx ny ny nz num_iter time\ndata = np.array( [ \\\n";
+  int size;
+#pragma omp parallel
+  {
+#pragma omp master
+    { size = omp_get_num_threads(); }
+  }
+  std::cout << "[ " << size << ", " << storage.xMax() - storage.xMin() << ", "
+            << storage.yMax() - storage.yMin() << ", " << storage.zMax() << ", "
+            << nIter << ", " << diff << "],\n";
+  std::cout << "] )" << std::endl;
+}
+} // namespace
+
+int main(int argc, char const *argv[]) {
+#ifdef CRAYPAT
+  PAT_record(PAT_STATE_OFF);
+#endif
+  int x = atoi(argv[2]);
+  int y = atoi(argv[4]);
+  int z = atoi(argv[6]);
+  unsigned int iter = atoi(argv[8]);
+  int nHalo = 3;
+  assert(x > 0 && y > 0 && z > 0 && iter > 0);
+
+  std::size_t zsize, xsize, ysize;
+  xsize = x + 2 * nHalo;
+  ysize = y + 2 * nHalo;
+  zsize = z;
+
+  Storage3D<float_type> input_3D(x, y, z, nHalo);
+  Storage3D<float_type> output_3D(x, y, z, nHalo);
+
+  input_3D.initialize();
+  output_3D.initialize();
+
+  std::size_t sizeOf3DField = (xsize) * (ysize) * (zsize);
+  float_type *input = new float_type[sizeOf3DField];
+  float_type *output = new float_type[sizeOf3DField];
+
+  // zero initialize the newly allocated array
+  for (std::size_t k = 0; k < zsize; ++k) {
+    for (std::size_t j = 0; j < ysize; ++j) {
+      for (std::size_t i = 0; i < xsize; ++i) {
+        std::size_t index1D = i + (j * xsize) + (k * xsize * ysize);
+        input[index1D] = 0;
+        output[index1D] = 0;
+      }
+    }
+  }
+
+  // initial condition
+  for (std::size_t k = zsize / 4.0; k < 3 * zsize / 4.0; ++k) {
+    for (std::size_t j = nHalo + xsize / 4.; j < nHalo + 3. / 4. * xsize; ++j) {
+      for (std::size_t i = nHalo + xsize / 4.; i < nHalo + 3. / 4. * xsize;
+           ++i) {
+        input[k * (ysize * xsize) + j * xsize + i] = 1;
+        output[k * (ysize * xsize) + j * xsize + i] = 1;
+      }
+    }
+  }
+
+  float_type alpha = 1. / 32.;
+
+  std::size_t xMax = xsize - nHalo;
+  std::size_t yMax = ysize - nHalo;
+  std::size_t zMax = zsize;
+
+  // float split_factor = 1;
+  std::size_t z_split = floor(split_factor * zMax);
+  std::size_t split_N =
+      (xMax - 1) + ((yMax - 1) * xsize) + ((z_split - 1) * xsize * ysize);
+
+  // std::size_t full_split_N =
+  //     (xMax - 1) + ((yMax - 1) * xsize) + ((zMax - 1) * xsize * ysize);
+  //
+  // std::cout << " splitN == " << split_N
+  //           << "== sizeof3D field = " << full_split_N << std::endl;
+  // assert(split_N == full_split_N);
+
+  // copy input to input_3D for writing to file
+  std::ofstream fout;
+  fout.open("in_field.dat", std::ios::binary | std::ofstream::trunc);
+  input_3D.writeFile(fout);
+  fout.close();
+
+#pragma acc enter data copyin(input [0:split_N]) copyin(output [0:split_N])
+
+#ifdef CRAYPAT
+  PAT_record(PAT_STATE_ON);
+#endif
+  auto start = std::chrono::steady_clock::now();
+
+  // apply_diffusion(input_3D, output_3D, alpha, iter, x, y, z, nHalo);
+  apply_diffusion(input, output, alpha, iter, xsize, ysize, zsize, nHalo);
+
+  auto end = std::chrono::steady_clock::now();
+#ifdef CRAYPAT
+  PAT_record(PAT_STATE_OFF);
+#endif
+
+  // updateHalo(output_3D);
+  updateHalo_gpu_out(output, xsize, ysize, zsize, nHalo, z_split);
+#pragma acc exit data copyout(output [0:split_N]) delete (input [0:split_N])
+  updateHalo_cpu(output, xsize, ysize, zsize, nHalo, z_split);
+
+  // updateHalo_cpu(output, xsize, ysize, zsize, nHalo);
+
+  // copy output array to output_3D for writing to file
+  for (std::size_t k = 0; k < zsize; ++k) {
+    for (std::size_t j = 0; j < ysize; ++j) {
+      for (std::size_t i = 0; i < xsize; ++i) {
+        std::size_t index1D = i + (j * xsize) + (k * xsize * ysize);
+        output_3D(i, j, k) = output[index1D];
+      }
+    }
+  }
+
+#ifdef VALIDATE
+  //--------------------------//
+  // run base and verification //
+  //--------------------------//
+  Storage3D<float_type> input_V(x, y, z, nHalo);
+  input_V.initialize();
+  Storage3D<float_type> output_V(x, y, z, nHalo);
+  output_V.initialize();
+  apply_diffusion(input_V, output_V, alpha, iter, x, y, z, nHalo);
+  updateHalo(output_V);
+  float_type L2_error = 0;
+  for (std::size_t k = 0; k < zsize; ++k) {
+    for (std::size_t j = 0; j < ysize; ++j) {
+      for (std::size_t i = 0; i < xsize; ++i) {
+        L2_error += std::pow((output_3D(i, j, k) - output_V(i, j, k)), 2);
+      }
+    }
+  }
+  L2_error = sqrt(L2_error);
+  std::cout << " L2 Error = " << L2_error << std::endl;
+  //--------------------------//
+  // run base and verification //
+  //--------------------------//
+#endif
+
+  fout.open("out_field.dat", std::ios::binary | std::ofstream::trunc);
+  output_3D.writeFile(fout);
+  fout.close();
+
+  auto diff = end - start;
+  float_type timeDiff =
+      std::chrono::duration<float_type, std::milli>(diff).count() / 1000.;
+  reportTime(output_3D, iter, timeDiff);
+
+  std::ofstream os;
+  os.open("time_1.dat", std::ofstream::app);
+  os << timeDiff << std::endl;
+  os.close();
+  delete[] input;
+  delete[] output;
+
+  return 0;
+}

--- a/projects2020/group03/src/openacc_split/stencil2d-arrayFusion-accsplit.cpp
+++ b/projects2020/group03/src/openacc_split/stencil2d-arrayFusion-accsplit.cpp
@@ -12,7 +12,7 @@
 #endif
 #include "../utils.h"
 
-#define split_factor 1
+float split_factor = 1.;
 
 typedef double float_type;
 // typedef float float_type;
@@ -613,6 +613,9 @@ int main(int argc, char const *argv[]) {
   unsigned int iter = atoi(argv[8]);
   int nHalo = 3;
   assert(x > 0 && y > 0 && z > 0 && iter > 0);
+
+  if (argc == 11)
+    split_factor = atof(argv[10]);
 
   std::size_t zsize, xsize, ysize;
   xsize = x + 2 * nHalo;

--- a/projects2020/group03/src/openacc_split/stencil2d_openacc_split.cmake
+++ b/projects2020/group03/src/openacc_split/stencil2d_openacc_split.cmake
@@ -1,0 +1,19 @@
+add_executable (
+	stencil2d_openacc_split
+		stencil2d.f
+		diffusion_openacc_split.f
+)
+target_compile_definitions (
+	stencil2d_openacc_split PRIVATE
+		-D m_diffusion=m_diffusion_openacc_split
+)
+target_link_libraries (
+	stencil2d_openacc_split
+		utils
+		partitioner
+		halo_mpi
+		OpenACC::Fortran
+		OpenMP::OpenMP_Fortran
+		MPI::MPI_Fortran
+)
+# vim : filetype=cmake noexpandtab tabstop=2 softtabs=2 shiftwidth=2 :


### PR DESCRIPTION
1.  updates and fixes the errors in the acc split version that seemed super fast
2.  adds new acc_split version in its respective folder 
 3. the acc_split version takes additional command line argument a float split_factor ( default value (no split) 1). To run : 
` ./run_stencil.x --nx 128 --ny 128 --nz 64 --num_iter 1024 --split 0.85`

4. [ Conflicts] just an update to the cmakelists inside the openacc_split folder. 
- Earlier it was a single cmakelists (since there was just a single file), now there's a cmake each file, hence the cmakelists just contains include statements. 

